### PR TITLE
Fix offline hook to support dynamodb offline

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ class serverlessPluginIfElse {
         this.options = options;
         this.hooks = {
             "before:package:initialize": this.applyConditions.bind(this),
-            "offline:start:init": this.applyConditions.bind(this),
+            "before:offline:start:init": this.applyConditions.bind(this),
         };
         this.pluginName = "serverless-plugin-ifelse";
     }


### PR DESCRIPTION
Hook "offline:start:init" run the pluging after dynamodb offline start.
To handle it to work with dynamodb offline, we need it to run before dynamodb offline start. So, we change the hook to "before:offline:start:init" 